### PR TITLE
Add theme toggle and fix dropdown opacity issues

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -24,28 +24,31 @@ import { Badge } from "@/components/ui/badge"
 import Mascot from "@/components/mascot"
 
 // 🌍 Language-specific mock data
-const locationData: Record<string, any> = {
+const locationData = {
   en: {
     location: "Delhi, India",
     weather: { temp: "28°C", humidity: "65%", wind: "12 km/h", condition: "Sunny" },
     crops: ["Wheat", "Rice", "Maize", "Mustard", "Sugarcane", "Sorghum"],
   },
-}
+} as const
+
+type LanguageCode = keyof typeof locationData
+const isLangSupported = (lang: string | null): lang is LanguageCode => !!lang && lang in locationData
 
 export default function Dashboard() {
   const [selectedCrop, setSelectedCrop] = useState<string>("")
-  const [language, setLanguage] = useState<"en">("en")
+  const [language, setLanguage] = useState<LanguageCode>("en")
   const [activeTab, setActiveTab] = useState("overview")
   const router = useRouter()
 
   useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search)
-    const lang = (urlParams.get("lang") as typeof language) || "en"
-    setLanguage(lang)
+    const params = new URLSearchParams(window.location.search)
+    const raw = params.get("lang")?.toLowerCase() || null
+    setLanguage(isLangSupported(raw) ? raw : "en")
   }, [])
 
   const handleLanguageChange = () => router.push("/")
-  const currentData = locationData[language]
+  const currentData = locationData[language] ?? locationData.en
 
   const t = {
     changeLang: "Change Language",

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -22,6 +22,7 @@ import VoiceChatbot from "@/components/voice-chatbot"
 import CropAnalytics from "@/components/crop-analytics"
 import { Badge } from "@/components/ui/badge"
 import Mascot from "@/components/mascot"
+import ThemeToggle from "@/components/ui/theme-toggle"
 
 // 🌍 Language-specific mock data
 const locationData = {
@@ -91,6 +92,7 @@ export default function Dashboard() {
                 <MapPin className="h-4 w-4 playful-icon" />
                 <span>{currentData.location}</span>
               </div>
+              <ThemeToggle />
               <Button className="playful-button" onClick={handleLanguageChange}>
                 {t.changeLang}
               </Button>
@@ -117,11 +119,11 @@ export default function Dashboard() {
                 </div>
                 <div className="confetti" aria-hidden>
                   {/* small decorative confetti elements */}
-                  <span style={{ left: '8%', top: '8%', background: '#F59E0B', animationDuration: '6s' }} />
-                  <span style={{ left: '28%', top: '4%', background: '#34D399', animationDuration: '5.5s' }} />
-                  <span style={{ left: '46%', top: '2%', background: '#60A5FA', animationDuration: '6.5s' }} />
-                  <span style={{ left: '68%', top: '6%', background: '#FB7185', animationDuration: '5s' }} />
-                  <span style={{ left: '86%', top: '10%', background: '#FDE68A', animationDuration: '7s' }} />
+                  <span className="confetti-dot confetti-dot-1" />
+                  <span className="confetti-dot confetti-dot-2" />
+                  <span className="confetti-dot confetti-dot-3" />
+                  <span className="confetti-dot confetti-dot-4" />
+                  <span className="confetti-dot confetti-dot-5" />
                 </div>
               </div>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -221,7 +221,7 @@
   inset: 0;
   overflow: hidden;
 }
-.confetti span {
+.confetti span, .confetti-dot {
   position: absolute;
   width: 10px;
   height: 16px;
@@ -229,6 +229,11 @@
   transform-origin: center;
   animation: confetti-fall linear infinite;
 }
+.confetti-dot-1 { left: 8%; top: 8%; background: #F59E0B; animation-duration: 6s; }
+.confetti-dot-2 { left: 28%; top: 4%; background: #34D399; animation-duration: 5.5s; }
+.confetti-dot-3 { left: 46%; top: 2%; background: #60A5FA; animation-duration: 6.5s; }
+.confetti-dot-4 { left: 68%; top: 6%; background: #FB7185; animation-duration: 5s; }
+.confetti-dot-5 { left: 86%; top: 10%; background: #FDE68A; animation-duration: 7s; }
 @keyframes confetti-fall {
   0% { transform: translateY(-10vh) rotate(0deg); opacity: 1; }
   100% { transform: translateY(110vh) rotate(720deg); opacity: 0.6; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from "geist/font/mono"
 import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
 import "./globals.css"
+import { ThemeProvider } from "@/components/theme-provider"
 
 export const metadata: Metadata = {
   title: "KrishiMitraAI - Smart Farming Assistant",
@@ -20,8 +21,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable} antialiased`}>
-        <Suspense fallback={null}>{children}</Suspense>
-        <Analytics />
+        <ThemeProvider attribute="class">
+          <Suspense fallback={null}>{children}</Suspense>
+          <Analytics />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,14 +19,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 opacity-100 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 opacity-100" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 opacity-100 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-card dark:bg-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 opacity-100 [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import * as React from "react"
+import { useTheme } from "next-themes"
+import { Sun, Moon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  const current = typeof theme === "string" ? theme : "light"
+  const isDark = current === "dark"
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label="Toggle color theme"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="flex items-center gap-2"
+    >
+      <Sun className={cn("h-4 w-4 transition-opacity", isDark ? "opacity-50" : "opacity-100")} />
+      <Moon className={cn("h-4 w-4 transition-opacity", isDark ? "opacity-100" : "opacity-50")} />
+    </Button>
+  )
+}


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses transparency issues with dropdown buttons and adds a requested dark mode toggle feature. Users reported that dropdown elements were appearing transparent in both light and dark modes, and requested a toggle button with sun and moon icons for theme switching.

## Code changes

- **Added theme toggle component**: Created `ThemeToggle` component with sun/moon icons that switches between light and dark themes
- **Fixed dropdown opacity**: Updated `SelectTrigger` styling to use `bg-card dark:bg-input` and set `opacity-100` to ensure proper visibility in both themes
- **Enhanced theme support**: Added `ThemeProvider` wrapper in root layout to enable theme switching functionality
- **Improved type safety**: Refactored language handling with proper TypeScript types and validation
- **Code cleanup**: Converted inline confetti styles to CSS classes for better maintainabilityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2cb898fdcfc64a008d3f9837bed0b2af/curry-works)

👀 [Preview Link](https://2cb898fdcfc64a008d3f9837bed0b2af-curry-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2cb898fdcfc64a008d3f9837bed0b2af</projectId>-->
<!--<branchName>curry-works</branchName>-->